### PR TITLE
request.REQUEST was removed in django 1.9

### DIFF
--- a/NextPlease/__init__.py
+++ b/NextPlease/__init__.py
@@ -14,7 +14,8 @@ class NextPleasePaginator (Paginator):
     
   def current (self):
     if not hasattr(self, '_current'):
-      page = self.request.REQUEST.get(self.page_param, '1')
+      data = self.request.POST or self.request.GET
+      page = data.get(self.page_param, '1')
       
       try:
         self._current = self.page(page)


### PR DESCRIPTION
first look at POST, then at GET